### PR TITLE
display space character in first or last name

### DIFF
--- a/ports/esp32/modules/gxgde0213b1.py
+++ b/ports/esp32/modules/gxgde0213b1.py
@@ -401,7 +401,7 @@ class EPD:
 				char  = ord(c) - font.first_char
 				w     = font.Glyphs[char][glyph_width]
 				h     = font.Glyphs[char][glyph_height]
-				if w > 0 and h > 0:
+				if w >= 0 and h >= 0:
 					xo    = font.Glyphs[char][glyph_xOffset]
 					yo    = font.Glyphs[char][glyph_yOffset]
 					xa    = font.Glyphs[char][glyph_xAdvance]


### PR DESCRIPTION
This change fixes an error in the logic of
G_display_string_at() which is used to display
the first and last name in a large font.

The space character is the first element in
G_FreeSans24pt7b.Glyphs. A bug in the logic
of G_display_string_at() was causing it to
skip displaying the first element.